### PR TITLE
[김희재]최근 검색어 및 인기 검색어 조회 인터페이스 추가

### DIFF
--- a/src/main/java/com/avengers/musinsa/domain/search/controller/PopularKeywordController.java
+++ b/src/main/java/com/avengers/musinsa/domain/search/controller/PopularKeywordController.java
@@ -1,20 +1,17 @@
 package com.avengers.musinsa.domain.search.controller;
 
 import com.avengers.musinsa.domain.search.dto.PopularKeywordResponseDTO;
-import com.avengers.musinsa.domain.search.dto.ResultDTO;
-import com.avengers.musinsa.domain.search.service.PopularKeywordService;
+import com.avengers.musinsa.domain.search.service.PopularKeywordServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/v1/search")
 @RequiredArgsConstructor
 public class PopularKeywordController {
-    private final PopularKeywordService popularKeywordService;
+    private final PopularKeywordServiceImpl popularKeywordService;
 
     @GetMapping("/popular-keyword")
    public PopularKeywordResponseDTO findPopularKeyword(){

--- a/src/main/java/com/avengers/musinsa/domain/search/controller/RecentSearchesResponseController.java
+++ b/src/main/java/com/avengers/musinsa/domain/search/controller/RecentSearchesResponseController.java
@@ -1,7 +1,7 @@
 package com.avengers.musinsa.domain.search.controller;
 
 import com.avengers.musinsa.domain.search.response.SearchKeywordResponseDTO;
-import com.avengers.musinsa.domain.search.service.RecentSearchService;
+import com.avengers.musinsa.domain.search.service.RecentSearchServiceImpl;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +15,7 @@ import java.util.List;
 @RequestMapping("/api/v1/search")
 @RequiredArgsConstructor
 public class RecentSearchesResponseController {
-    private final RecentSearchService recentSearchService;
+    private final RecentSearchServiceImpl recentSearchService;
 
     @GetMapping("/recent")
     public List<SearchKeywordResponseDTO> recentSearches(@RequestParam Long userId) {

--- a/src/main/java/com/avengers/musinsa/domain/search/service/PopularKeywordService.java
+++ b/src/main/java/com/avengers/musinsa/domain/search/service/PopularKeywordService.java
@@ -1,28 +1,8 @@
 package com.avengers.musinsa.domain.search.service;
 
 import com.avengers.musinsa.domain.search.dto.PopularKeywordResponseDTO;
-import com.avengers.musinsa.domain.search.dto.ResultDTO;
-import com.avengers.musinsa.domain.search.repository.PopularKeywordRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.util.List;
+public interface PopularKeywordService {
+    PopularKeywordResponseDTO getTrendingKeywords();
 
-@Service
-@RequiredArgsConstructor
-public class PopularKeywordService {
-    private final PopularKeywordRepository popularKeywordRepository;
-
-    public PopularKeywordResponseDTO getTrendingKeywords(){
-        List<ResultDTO> trendingKeywords = popularKeywordRepository.findTrendingKeywords();
-
-        return PopularKeywordResponseDTO.builder()
-                .basedOnTime(LocalDateTime.now().toString())
-                .message("인기 검색어 조회 성공")
-                .success(true)
-                .results(trendingKeywords)
-                .build();
-    }
 }
-

--- a/src/main/java/com/avengers/musinsa/domain/search/service/PopularKeywordServiceImpl.java
+++ b/src/main/java/com/avengers/musinsa/domain/search/service/PopularKeywordServiceImpl.java
@@ -1,0 +1,29 @@
+package com.avengers.musinsa.domain.search.service;
+
+import com.avengers.musinsa.domain.search.dto.PopularKeywordResponseDTO;
+import com.avengers.musinsa.domain.search.dto.ResultDTO;
+import com.avengers.musinsa.domain.search.repository.PopularKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PopularKeywordServiceImpl implements PopularKeywordService {
+    private final PopularKeywordRepository popularKeywordRepository;
+
+    @Override
+    public PopularKeywordResponseDTO getTrendingKeywords(){
+        List<ResultDTO> trendingKeywords = popularKeywordRepository.findTrendingKeywords();
+
+        return PopularKeywordResponseDTO.builder()
+                .basedOnTime(LocalDateTime.now().toString())
+                .message("인기 검색어 조회 성공")
+                .success(true)
+                .results(trendingKeywords)
+                .build();
+    }
+}
+

--- a/src/main/java/com/avengers/musinsa/domain/search/service/RecentSearchService.java
+++ b/src/main/java/com/avengers/musinsa/domain/search/service/RecentSearchService.java
@@ -1,18 +1,9 @@
 package com.avengers.musinsa.domain.search.service;
 
 import com.avengers.musinsa.domain.search.response.SearchKeywordResponseDTO;
-import com.avengers.musinsa.domain.search.repository.RecentSearchRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Service
-@RequiredArgsConstructor
-public class RecentSearchService {
-    private final RecentSearchRepository recentSearchRepository;
-
-    public List<SearchKeywordResponseDTO> getRecentSearches(Long userId) {
-        return recentSearchRepository.findRecentSearches(userId);
-    }
+public interface RecentSearchService {
+    List<SearchKeywordResponseDTO> getRecentSearches(Long userId);
 }

--- a/src/main/java/com/avengers/musinsa/domain/search/service/RecentSearchServiceImpl.java
+++ b/src/main/java/com/avengers/musinsa/domain/search/service/RecentSearchServiceImpl.java
@@ -1,0 +1,19 @@
+package com.avengers.musinsa.domain.search.service;
+
+import com.avengers.musinsa.domain.search.response.SearchKeywordResponseDTO;
+import com.avengers.musinsa.domain.search.repository.RecentSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RecentSearchServiceImpl implements RecentSearchService {
+    private final RecentSearchRepository recentSearchRepository;
+
+    @Override
+    public List<SearchKeywordResponseDTO> getRecentSearches(Long userId) {
+        return recentSearchRepository.findRecentSearches(userId);
+    }
+}


### PR DESCRIPTION
- PopularKeywordService와 PopularKeywordServiceImpl로 분리
<img width="862" height="612" alt="image" src="https://github.com/user-attachments/assets/d9dd32cc-0c8d-4b33-a76b-a6141b7ef8c8" />


<img width="856" height="385" alt="image" src="https://github.com/user-attachments/assets/cd9b68ab-ab87-46c1-939a-db613884831a" />

- RecentSearchService 와 RecentServiceImpl로 분리
<img width="879" height="407" alt="image" src="https://github.com/user-attachments/assets/7b9cc701-fbf7-44f7-a53f-d730aea4b8ca" />

<img width="815" height="530" alt="image" src="https://github.com/user-attachments/assets/e440bb22-31a9-4604-888d-f134b72c35cb" />


