### PR TITLE
[조현희] fix: 상품 상세화면 브랜드 이미지 흑백 반전 적용

### DIFF
--- a/src/main/webapp/resources/css/productDetailPage.css
+++ b/src/main/webapp/resources/css/productDetailPage.css
@@ -500,6 +500,7 @@ a {
     width: 100%;
     height: 100%;
     object-fit: contain;
+    filter: invert(1);
 }
 
 .brand-header > .brand-name {


### PR DESCRIPTION
<img width="1510" height="704" alt="image" src="https://github.com/user-attachments/assets/2bfe05a1-d86a-49a5-8204-b3298acb1597" />
