### PR TITLE
[김진용] 평점(베이지안 평점 보정) + 판매량 + 좋아요개수 + 리뷰 수 기준으로 상품 추천 정렬 쿼리 추가

### DIFF
--- a/src/main/resources/mapper/ProductMapper.xml
+++ b/src/main/resources/mapper/ProductMapper.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.avengers.musinsa.mapper.ProductMapper">
-    <resultMap id="ProductDetailResultMap" type="com.avengers.musinsa.domain.product.dto.response.ProductDetailResponse">
+    <resultMap id="ProductDetailResultMap"
+               type="com.avengers.musinsa.domain.product.dto.response.ProductDetailResponse">
         <result property="productId" column="productId"/>
         <result property="productName" column="productName"/>
         <result property="productLikeCnt" column="productLikeCnt"/>
@@ -93,7 +94,8 @@
                      END
     </select>
 
-    <resultMap id="RecommendationResultMap" type="com.avengers.musinsa.domain.product.dto.response.RecommendationResponse">
+    <resultMap id="RecommendationResultMap"
+               type="com.avengers.musinsa.domain.product.dto.response.RecommendationResponse">
         <result property="productId" column="productId"/>
         <result property="brandId" column="brandId"/>
         <result property="productName" column="productName"/>
@@ -105,27 +107,63 @@
     </resultMap>
 
     <select id="getRecommendationProductList" resultMap="RecommendationResultMap">
-        SELECT p.product_id                                                AS productId,
-               b.brand_id                                                  AS brandId,
-               p.product_name                                              AS productName,
-               b.brand_name_kr                                             AS productBrand,
-               FLOOR(((100 - b.BRAND_DISCOUNT) / 100) * p.price / 10) * 10 AS productPrice,
-               img.image_url                                               AS productImage,
-               b.brand_discount                                            as discountRate,
-               CASE WHEN upl.LIKED = 1 THEN 1 ELSE 0 END                   AS isLiked
+        WITH global_rating AS (SELECT NVL(AVG(r.rating), 0) AS C, 10 AS m
+        FROM REVIEWS r)
+
+        SELECT p.product_id AS productId,
+        b.brand_id AS brandId,
+        p.product_name AS productName,
+        b.brand_name_kr AS productBrand,
+        FLOOR(((100 - b.BRAND_DISCOUNT) / 100) * p.price / 10) * 10 AS productPrice,
+        img.image_url AS productImage,
+        b.brand_discount as discountRate,
+        CASE WHEN upl.LIKED = 1 THEN 1 ELSE 0 END AS isLiked
 
         FROM products p
-                 JOIN brands b
-                      ON b.brand_id = p.brand_id
-                 LEFT JOIN product_images img
-                           ON p.product_id = img.product_id
-                               AND img.image_type = 'MAIN'
-                 LEFT JOIN USER_PRODUCT_LIKES upl
-                           ON upl.PRODUCT_ID = p.PRODUCT_ID
-                               AND upl.user_id = #{userId}
+        JOIN brands b
+        ON b.brand_id = p.brand_id
+
+        LEFT JOIN product_images img
+        ON p.product_id = img.product_id
+        AND img.image_type = 'MAIN'
+
+        LEFT JOIN USER_PRODUCT_LIKES upl
+        ON upl.PRODUCT_ID = p.PRODUCT_ID
+        AND upl.user_id = #{userId}
+
+        LEFT JOIN (SELECT oi.PRODUCT_ID, SUM(oi.QUANTITY) AS total_sales
+        FROM ORDER_ITEMS oi
+        JOIN ORDERS O
+        ON o.ORDER_ID = oi.ORDER_ID
+        AND o.ORDER_STATUS IN ('PAID', 'COMPLETED')
+        GROUP BY oi.PRODUCT_ID) tp
+        ON tp.PRODUCT_ID = p.PRODUCT_ID
+
+        LEFT JOIN (SELECT r.PRODUCT_ID, COUNT(*) AS review_count, AVG(r.RATING) AS review_rating
+        FROM REVIEWS r
+        GROUP BY r.PRODUCT_ID) rp
+        ON rp.PRODUCT_ID = p.PRODUCT_ID
+
+        LEFT JOIN (SELECT upl.PRODUCT_ID, COUNT(*) AS like_count
+        FROM USER_PRODUCT_LIKES upl
+        GROUP BY upl.PRODUCT_ID) lp
+        ON lp.PRODUCT_ID = p.PRODUCT_ID
+
+        CROSS JOIN global_rating gr
+
         WHERE p.gender = #{gender}
-        ORDER BY p.created_at DESC
-            FETCH FIRST 32 ROWS ONLY
+        ORDER BY (
+        NVL(tp.total_sales, 0) * 0.3 +
+        NVL(rp.review_count, 0) * 0.2 +
+        NVL(lp.like_count, 0) * 0.2 +
+        <!-- 베이지안 평점 * 0.4 -->
+        (
+        (NVL(rp.review_count, 0) / (NVL(rp.review_count, 0) + gr.m)) * NVL(rp.review_rating, gr.C) +
+        (gr.m / (NVL(rp.review_count, 0) + gr.m)) * gr.C
+        ) * 0.4
+        ) DESC,
+        p.created_at DESC
+        FETCH FIRST 32 ROWS ONLY
     </select>
 
     <select id="findOptionsByProductIds"
@@ -147,7 +185,8 @@
         </foreach>
     </select>
 
-    <resultMap id="ProductByCategoryResultMap" type="com.avengers.musinsa.domain.product.dto.response.ProductByCategoryResponse">
+    <resultMap id="ProductByCategoryResultMap"
+               type="com.avengers.musinsa.domain.product.dto.response.ProductByCategoryResponse">
         <result property="productId" column="productId"/>
         <result property="productName" column="productName"/>
         <result property="productImage" column="productImage"/>
@@ -160,50 +199,50 @@
     </resultMap>
 
     <select id="getProductsByCategory" resultMap="ProductByCategoryResultMap">
-        SELECT ranked_products.product_id    as productId,
-               ranked_products.product_name  as productName,
-               pimg.image_url                as productImage,
-               b.brand_name_kr               as brandName,
-               ranked_products.price         as price,
-               ranked_products.product_likes as productLikes,
-               ranked_products.rating_avg    as ratingAverage,
-               ranked_products.review_count  as reviewCount,
-               ranked_products.recommendation_score as recommendationScore,
-               CASE WHEN upl.LIKED = 1 THEN 1 ELSE 0 END AS isLiked
+        SELECT ranked_products.product_id as productId,
+        ranked_products.product_name as productName,
+        pimg.image_url as productImage,
+        b.brand_name_kr as brandName,
+        ranked_products.price as price,
+        ranked_products.product_likes as productLikes,
+        ranked_products.rating_avg as ratingAverage,
+        ranked_products.review_count as reviewCount,
+        ranked_products.recommendation_score as recommendationScore,
+        CASE WHEN upl.LIKED = 1 THEN 1 ELSE 0 END AS isLiked
 
         FROM (SELECT p.product_id,
-                     p.product_name,
-                     p.brand_id,
-                     p.price,
-                     p.product_likes,
-                     prs.rating_avg,
-                     prs.review_count,
-                     -- 가중치 계산
-                     (
-                         NVL(order_stats.total_orders, 0) * 10.0 +
-                         NVL(prs.rating_avg, 3.0) * 5.0 +
-                         NVL(p.product_likes, 0) * 2.0
-                         ) AS recommendation_score
-              FROM products p
+        p.product_name,
+        p.brand_id,
+        p.price,
+        p.product_likes,
+        prs.rating_avg,
+        prs.review_count,
+        -- 가중치 계산
+        (
+        NVL(order_stats.total_orders, 0) * 10.0 +
+        NVL(prs.rating_avg, 3.0) * 5.0 +
+        NVL(p.product_likes, 0) * 2.0
+        ) AS recommendation_score
+        FROM products p
 
-                       -- 주문 통계 (상품별 총 주문 수)
-                       LEFT JOIN (SELECT oi.product_id, COUNT(oi.order_item_id) AS total_orders
-                                  FROM order_items oi
-                                           JOIN orders o ON o.order_id = oi.order_id
-                                  WHERE o.order_status NOT IN ('취소', '반품완료')
-                                  GROUP BY oi.product_id) order_stats
-                                 ON order_stats.product_id = p.product_id
+        -- 주문 통계 (상품별 총 주문 수)
+        LEFT JOIN (SELECT oi.product_id, COUNT(oi.order_item_id) AS total_orders
+        FROM order_items oi
+        JOIN orders o ON o.order_id = oi.order_id
+        WHERE o.order_status NOT IN ('취소', '반품완료')
+        GROUP BY oi.product_id) order_stats
+        ON order_stats.product_id = p.product_id
 
-                  -- 리뷰 평점 통계
-                       LEFT JOIN (SELECT prs.product_id, prs.review_count, prs.rating_avg
-                                  FROM product_review_stats prs) prs ON p.product_id = prs.product_id
-              WHERE p.product_category_id = #{categoryId}) ranked_products
-                 JOIN brands b
-                      ON b.brand_id = ranked_products.brand_id
-                 JOIN product_images pimg ON pimg.product_id = ranked_products.product_id
-                 LEFT JOIN USER_PRODUCT_LIKES upl
-                           ON upl.PRODUCT_ID = ranked_products.product_id
-                               AND upl.user_id = #{userId}
+        -- 리뷰 평점 통계
+        LEFT JOIN (SELECT prs.product_id, prs.review_count, prs.rating_avg
+        FROM product_review_stats prs) prs ON p.product_id = prs.product_id
+        WHERE p.product_category_id = #{categoryId}) ranked_products
+        JOIN brands b
+        ON b.brand_id = ranked_products.brand_id
+        JOIN product_images pimg ON pimg.product_id = ranked_products.product_id
+        LEFT JOIN USER_PRODUCT_LIKES upl
+        ON upl.PRODUCT_ID = ranked_products.product_id
+        AND upl.user_id = #{userId}
 
         WHERE pimg.image_type = 'MAIN'
         <choose>
@@ -363,7 +402,8 @@
            OR brand_name_eng = #{keyword} LIMIT 1
     </select>
 
-    <resultMap id="SearchProductInfoResultMap" type="com.avengers.musinsa.domain.product.dto.search.SearchResponse$ProductInfo">
+    <resultMap id="SearchProductInfoResultMap"
+               type="com.avengers.musinsa.domain.product.dto.search.SearchResponse$ProductInfo">
         <result property="brandId" column="brandId"/>
         <result property="brandNameKr" column="brandNameKr"/>
         <result property="brandNameEn" column="brandNameEn"/>
@@ -378,24 +418,24 @@
     </resultMap>
 
     <select id="findProductsByBrandId" resultMap="SearchProductInfoResultMap">
-        SELECT b.brand_id       as brandId,
-               b.brand_name_kr  as brandNameKr,
-               b.brand_name_eng as brandNameEn,
-               p.product_id     as productId,
-               pi.image_url     as productImage,
-               p.product_name   as productName,
-               p.price,
-               p.product_likes  as productLikes,
-               prs.rating_avg   as ratingAverage,
-               prs.review_count as reviewCount,
-               CASE WHEN upl.LIKED = 1 THEN 1 ELSE 0 END AS isLiked
+        SELECT b.brand_id as brandId,
+        b.brand_name_kr as brandNameKr,
+        b.brand_name_eng as brandNameEn,
+        p.product_id as productId,
+        pi.image_url as productImage,
+        p.product_name as productName,
+        p.price,
+        p.product_likes as productLikes,
+        prs.rating_avg as ratingAverage,
+        prs.review_count as reviewCount,
+        CASE WHEN upl.LIKED = 1 THEN 1 ELSE 0 END AS isLiked
         FROM products p
-                 JOIN brands b ON p.brand_id = b.brand_id
-                 LEFT JOIN product_images pi ON p.product_id = pi.product_id AND pi.image_type = 'MAIN'
-                 LEFT JOIN product_review_stats prs ON p.product_id = prs.product_id
-                 LEFT JOIN USER_PRODUCT_LIKES upl
-                           ON upl.PRODUCT_ID = p.PRODUCT_ID
-                               AND upl.user_id = #{userId}
+        JOIN brands b ON p.brand_id = b.brand_id
+        LEFT JOIN product_images pi ON p.product_id = pi.product_id AND pi.image_type = 'MAIN'
+        LEFT JOIN product_review_stats prs ON p.product_id = prs.product_id
+        LEFT JOIN USER_PRODUCT_LIKES upl
+        ON upl.PRODUCT_ID = p.PRODUCT_ID
+        AND upl.user_id = #{userId}
         WHERE p.brand_id = #{brandId}
         <choose>
             <when test="sortBy == 'PRICE_LOW'">
@@ -427,8 +467,8 @@
         LEFT JOIN product_images pi ON p.product_id = pi.product_id AND pi.image_type = 'MAIN'
         LEFT JOIN product_review_stats prs ON p.product_id = prs.product_id
         LEFT JOIN USER_PRODUCT_LIKES upl
-                  ON upl.PRODUCT_ID = p.PRODUCT_ID
-                      AND upl.user_id = #{userId}
+        ON upl.PRODUCT_ID = p.PRODUCT_ID
+        AND upl.user_id = #{userId}
         WHERE (
         <foreach collection="keywords" item="keyword" separator=" OR ">
             p.product_name LIKE '%' || #{keyword, jdbcType=VARCHAR} || '%'


### PR DESCRIPTION
## 추천 정렬 로직 개선 — 베이지안 평점 보정

* 전역 평균(C)과 사전 가중치(m)로 **베이지안 보정 평점** 계산해서 정렬 가중합에 추가.

* 리뷰가 1~2개여도 평균이 5.0이면 상단 과대노출됨 → 표본 수 반영해서 안정화.
* 리뷰가 많아질수록 원래 평균에 수렴, 적을수록 전역 평균으로 당겨져 왜곡 완화.

**공식**

* `rating_score = (v/(v+m))*R + (m/(v+m))*C`

  * `R`: 상품 평균 평점, `v`: 리뷰 수, `C`: 전역 평균, `m`: 사전 가중치(예: 10)

**정렬식(가중치 예시)**

* `0.3*판매 + 0.2*리뷰수 + 0.2*좋아요 + 0.4*베이지안평점`

**숫자 예시 (C=3.9, m=10)**

* R=5.0, v=2 → 4.083 (초기 과대평가 완화)
* R=4.6, v=50 → 4.483 (원래 값에 근접)
* v=0 → 3.9(=C)

**SQL**

* `WITH global_rating AS (SELECT AVG(r.rating) AS C, 10 AS m FROM reviews)`
* `CROSS JOIN global_rating gr`
* ```
  (
    (NVL(v,0)/(NVL(v,0)+gr.m)) * NVL(R, gr.C) +
    (gr.m/(NVL(v,0)+gr.m))     * gr.C
  )
  ```

* m은 팀에서 튜닝(예: 5~20).
* 원하면 최근 N개월만 집계해서 최신성 반영 가능.
