### PR TITLE
[조현희] 장바구니 - 동일 옵션 중복 존재 해결

### DIFF
--- a/src/main/java/com/avengers/musinsa/domain/user/repository/CartRepository.java
+++ b/src/main/java/com/avengers/musinsa/domain/user/repository/CartRepository.java
@@ -23,9 +23,9 @@ public class CartRepository {
         return cartMapper.productOptionInfo(userId, productId, productOptions);
     }
 
-    public void updateProductOption(Long userId, Long productId, String productOptionName,
+    public void updateProductOption(Long userCartId, String productOptionName,
                                     Integer quantity) {
-        cartMapper.updateProductOption(userId, productId, productOptionName, quantity);
+        cartMapper.updateProductOption(userCartId, productOptionName, quantity);
     }
 
     // userId와 productVariantId로 이전에 장바구니를 추가했는지 확인하는 메서드

--- a/src/main/java/com/avengers/musinsa/domain/user/service/CartService.java
+++ b/src/main/java/com/avengers/musinsa/domain/user/service/CartService.java
@@ -11,6 +11,8 @@ import com.avengers.musinsa.domain.user.repository.CartRepository;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
 import com.avengers.musinsa.mapper.CartMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -32,8 +34,11 @@ public class CartService {
         CartItemDto existingItem = cartRepository.findCartItemByVariantId(userId, request);
 
         if (existingItem != null) {
-            // 4. 상품이 이미 있으면: 수량 업데이트
-
+            // 같은 상품, 같은 옵션, 같은 수량일 경우
+            if (existingItem.getQuantity().equals(request.getQuantity())) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "DUPLICATE_ITEM");
+            }
+            // 4. 수량만 다를 경우, 기존 수량 업데이트
             cartRepository.updateCartItemQuantity(existingItem.getCartId(), request.getQuantity());
         } else {
             // 5. 상품이 없으면: 새로 추가
@@ -81,11 +86,33 @@ public class CartService {
             String message = "최대 " + availableQuantity + "개의 상품만 구매할 수 있습니다.";
             throw new ResponseStatusException(HttpStatus.CONFLICT, "QUANTITY_4091" + message);
         }
+        String newOptionName = productOptionInfo.getOptionName();
 
-        // 외의 경우 장바구니의 해당 상품 옵션 변경
-        cartRepository.updateProductOption(userId, productId, productOptionInfo.getOptionName(), updateQuantity);
+        // 동일 옵션 중복 여부 확인
+        List<ProductsInCartInfoResponse> cartItems = cartRepository.getProductsInCart(userId);
 
-        // 장바구니 상품 목록 반환
+        // 현재 수정하려는 장바구니 항목의 userCartId 찾기
+        Long userCartId = cartItems.stream()
+                .filter(item -> item.getProductId().equals(productId))
+                .map(ProductsInCartInfoResponse::getUserCartId)
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "장바구니 항목을 찾을 수 없습니다."));
+
+        Optional<ProductsInCartInfoResponse> duplicate = cartItems.stream()
+                .filter(item -> !item.getUserCartId().equals(userCartId)) // 현재 수정 대상 제외
+                .filter(item -> item.getOptionName().equals(newOptionName)) // 동일 옵션 체크
+                .findFirst();
+
+        if (duplicate.isPresent()) {
+            // 장바구니 내 기존 동일 옵션 항목 삭제
+            cartRepository.deleteCartItems(userId, List.of(duplicate.get().getUserCartId()));
+            // 수정 대상 항목은 업데이트
+            cartRepository.updateProductOption(userCartId, newOptionName, updateQuantity);
+        } else {
+            // 중복 없으면 수정 대상 업데이트
+            cartRepository.updateProductOption(userCartId, newOptionName, updateQuantity);
+        }
+        // 5. 최신 장바구니 반환
         return getProductsInCart(userId);
     }
 

--- a/src/main/java/com/avengers/musinsa/mapper/CartMapper.java
+++ b/src/main/java/com/avengers/musinsa/mapper/CartMapper.java
@@ -13,7 +13,7 @@ public interface CartMapper {
 
     ProductOptionInfo productOptionInfo(Long userId, Long productId, Map<Integer, String> productOptions);
 
-    void updateProductOption(Long userId, Long productId, String productOptionName, Integer quantity);
+    void updateProductOption(Long userCartId, String productOptionName, Integer quantity);
 
     CartItemDto findCartItemByVariantId(@Param("userId") Long userId, @Param("request") AddCartRequest request);
 

--- a/src/main/resources/mapper/CartMapper.xml
+++ b/src/main/resources/mapper/CartMapper.xml
@@ -54,8 +54,7 @@
         UPDATE USER_CARTS
         SET CART_OPTION=#{productOptionName},
             CART_QUANTITY=#{quantity}
-        WHERE USER_ID = #{userId}
-          AND PRODUCT_ID = #{productId}
+        WHERE USER_CART_ID = #{userCartId}
     </update>
 
     <!--    userId와 productVariantId를 이용해 장바구니 찾기-->


### PR DESCRIPTION
**문제**

1. 장바구니 수정 중, 변경한 옵션이 이미 존재하는 다른 항목과 동일한 경우 중복으로 존재
2. 같은 상품의 모든 옵션이 동시에 변경됨


**해결**

1. 옵션 수정 시 장바구니 내 동일 옵션 존재 여부 확인 → 중복 발견 시 기존 항목 삭제 후 현재 항목만 업데이트
2. userCartId 기준 업데이트 → 선택한 특정 장바구니 항목만 변경됨